### PR TITLE
change image pull policy to always for raster tiler

### DIFF
--- a/helm/raster-tiler/templates/deployment.yaml
+++ b/helm/raster-tiler/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
               value: "true"
           {{- end }}
           image: {{ .Values.image.name }}:{{ .Values.image.tag }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
         {{- if .Values.createResource.deploymentLivenessProbe }}
           livenessProbe:
             failureThreshold: 10


### PR DESCRIPTION
`IfNotPresent` pull policy doesn't allow me to restart pod with the latest version of docker image with tag `latest` on dev.