### PR TITLE
17318 insights-api postgres set default_statistics_target to 10000

### DIFF
--- a/flux/clusters/k8s-01/insights-api-db/base/postgrescluster.yaml
+++ b/flux/clusters/k8s-01/insights-api-db/base/postgrescluster.yaml
@@ -72,6 +72,7 @@ spec:
           autovacuum_vacuum_cost_limit: -1
           autovacuum_vacuum_insert_scale_factor: 0.01
           autovacuum_vacuum_scale_factor: 0.01
+          default_statistics_target: 10000
           effective_cache_size: 60GB
           effective_io_concurrency: 200
           log_autovacuum_min_duration: 250ms


### PR DESCRIPTION
setting is needed to keep actual stats on indicators, so that heavy queries from insights-db use optimal plan