### PR TITLE
Addded initcontainer for basemap cronjob

### DIFF
--- a/helm/basemap/templates/cronjobs.yaml
+++ b/helm/basemap/templates/cronjobs.yaml
@@ -18,6 +18,25 @@ spec:
     spec:
       template:
         spec:
+          initContainers:
+          - name: check-pvc-usage
+            image: nexus.kontur.io:8085/konturdev/check-pod-pvc:1.12
+            imagePullPolicy: IfNotPresent
+            volumeMounts:
+            - name: kubeconfig-volume
+              mountPath: "/root/.kube"
+              readOnly: true
+            env:
+            - name: KUBECONFIG
+              value: "/root/.kube/config"
+            - name: PVC_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: PVC_NAME
+              value: {{ .Values.envName }}-basemap-postgres-pvc
+            - name: CURRENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           shareProcessNamespace: true # required to shut down postgres when pipeline is done
           restartPolicy: Never
           {{ if .Values.images.usePullSecret }}
@@ -105,4 +124,7 @@ spec:
           - name: {{ .Values.envName }}-basemap-postgres-pvc
             persistentVolumeClaim:
               claimName: {{ .Values.envName }}-basemap-postgres-pvc
+          - name: kubeconfig-volume
+            secret:
+              secretName: {{ .Values.envName }}-basemap-kubeconfig
 ---

--- a/helm/basemap/templates/cronjobs.yaml
+++ b/helm/basemap/templates/cronjobs.yaml
@@ -26,6 +26,13 @@ spec:
             - name: kubeconfig-volume
               mountPath: "/root/.kube"
               readOnly: true
+            resources:
+              limits:
+                memory: {{ .Values.resources.check-pvc-usage.limits.memory | quote }}
+                cpu: {{ .Values.resources.check-pvc-usage.limits.cpu | quote } }
+              requests:
+                memory: {{ .Values.resources.check-pvc-usage.requests.memory | quote }}
+                cpu: {{ .Values.resources.check-pvc-usage.requests.cpu | quote }}
             env:
             - name: KUBECONFIG
               value: "/root/.kube/config"

--- a/helm/basemap/values.yaml
+++ b/helm/basemap/values.yaml
@@ -69,3 +69,10 @@ resources:
     requests:
       memory: 64Gi
       cpu: '10'
+  check-pvc-usage:
+    limits:
+      memory: 200Mi
+      cpu: 200m
+    requests:
+      memory: 100Mi
+      cpu: 100m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced PVC (Persistent Volume Claim) management by adding an `initContainer` to cronjobs for monitoring PVC usage.
	- Included resource limits and requests for memory and CPU in the `check-pvc-usage` section of values.yaml.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->