### PR TITLE
deploy insights-api-db-svc on test

### DIFF
--- a/helm/insights-api-db-svc/Chart.yaml
+++ b/helm/insights-api-db-svc/Chart.yaml
@@ -16,6 +16,6 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.5
+version: 0.0.6
 
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/insights-api-db-svc/values/values-test.yaml
+++ b/helm/insights-api-db-svc/values/values-test.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  tag: main.0992170.1
+  tag: main.7e22e02.1
   tagType: ""
   pullSecretName: none
   usePullSecret: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version number of the insights API database service chart to `0.0.6`.
	- Updated the insights API database service image tag for testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->