### PR TITLE
Deploy old DN version with MCDA text prompt for testing purposes (Dev)

### DIFF
--- a/helm/disaster-ninja-fe/Chart.yaml
+++ b/helm/disaster-ninja-fe/Chart.yaml
@@ -16,6 +16,6 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.173
+version: 0.3.174
 #Don't use appVersion, use {{ .Values.image.fe.tag }} instead. That's required for Flux automation - so that different
 # stages can have different versions within the same branch watched by Flux.

--- a/helm/disaster-ninja-fe/values/values-dev.yaml
+++ b/helm/disaster-ninja-fe/values/values-dev.yaml
@@ -6,7 +6,7 @@ image:
   fe:
     repository: ghcr.io/konturio/disaster-ninja-fe
     algorithm: ""
-    tag: release-2.23.1.1fde5ba.1
+    tag: old-mcda-json-dialog.561028c.1
 
 replicaCount: 2
 envName: dev


### PR DESCRIPTION
Deploy old DN version with MCDA text prompt for testing purposes (Dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the image tag for the `disaster-ninja-fe` service to enhance operational efficiency.
- **Documentation**
	- Incremented the application version from `0.3.173` to `0.3.174` in the `Chart.yaml` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->