### PR TITLE
14031-add-aws-cli-to-layers-db-etl-dockerfile

### DIFF
--- a/helm/layers-db-etl/Chart.yaml
+++ b/helm/layers-db-etl/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.54
+version: 0.1.55
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/layers-db-etl/values/values-test.yaml
+++ b/helm/layers-db-etl/values/values-test.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  tag: release-1.4.13.bc72d67.1
+  tag: 14031-add-aws-cli-to-layers-db-etl-dockerfile.8ff212c.1
   usePullSecret: false
   pullSecretName: none
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Helm chart for the layers-db-etl to version `0.1.55`.
	- Updated the Docker image used in the layers-db-etl to include AWS CLI support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->