### PR TITLE
deploy DN 2.24.0 to PROD and TEST

### DIFF
--- a/helm/disaster-ninja-fe/Chart.yaml
+++ b/helm/disaster-ninja-fe/Chart.yaml
@@ -16,6 +16,6 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.176
+version: 0.3.177
 #Don't use appVersion, use {{ .Values.image.fe.tag }} instead. That's required for Flux automation - so that different
 # stages can have different versions within the same branch watched by Flux.

--- a/helm/disaster-ninja-fe/values/values-prod.yaml
+++ b/helm/disaster-ninja-fe/values/values-prod.yaml
@@ -6,7 +6,7 @@ image:
   fe:
     repository: ghcr.io/konturio/disaster-ninja-fe
     algorithm: ''
-    tag: release-2.23.1.1fde5ba.1
+    tag: release-2.24.0.107b449.1
 
 replicaCount: 2
 envName: prod

--- a/helm/disaster-ninja-fe/values/values-test.yaml
+++ b/helm/disaster-ninja-fe/values/values-test.yaml
@@ -6,7 +6,7 @@ image:
   fe:
     repository: ghcr.io/konturio/disaster-ninja-fe
     algorithm: ''
-    tag: main.adbba0e.1
+    tag: release-2.24.0.107b449.1
 
 replicaCount: 2
 envName: test


### PR DESCRIPTION
- feat(17479): Edit MCDA functionality (https://github.com/konturio/disaster-ninja-fe/pull/668)
- fix(bivariate_matrix): 17663 no legend for bivariate matrix layers (https://github.com/konturio/disaster-ninja-fe/pull/667)
- fix(17879): MCDA form: scroll at layers dropdown is non operable (https://github.com/konturio/disaster-ninja-fe/pull/670)
- fix: 15027: save public feed after page reload (https://github.com/konturio/disaster-ninja-fe/pull/671)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application version to `0.3.177`.
- **New Features**
	- Upgraded the `disaster-ninja-fe` application to version `2.24.0` in both production and test environments for enhanced features and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->