### PR TITLE
Bump raster-tiler version and image tags

### DIFF
--- a/helm/raster-tiler/Chart.yaml
+++ b/helm/raster-tiler/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.70
+version: 0.0.71
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/raster-tiler/values/values-dev.yaml
+++ b/helm/raster-tiler/values/values-dev.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  tag: 855746d73447fb4d6d8c73e0c71355dca82dd04a
+  tag: 5ecdccd134d2e7059e67307b0a3288c18e58ce70
   pullSecretName: none
   usePullSecret: false
 

--- a/helm/raster-tiler/values/values-test.yaml
+++ b/helm/raster-tiler/values/values-test.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  tag: ef07e1365740a7bd86e455cead198e19ddc196d0
+  tag: 5ecdccd134d2e7059e67307b0a3288c18e58ce70
   pullSecretName: none
   usePullSecret: false
 


### PR DESCRIPTION
Update the raster-tiler Helm chart to version 0.0.71 and synchronize the image tags across development and test environments to 5ecdccd134d2e7059e67307b0a3288c18e58ce70. This ensures consistency and the use of the latest image in both environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the raster tiler service to a new version for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->