### PR TITLE
Bump raster-tiler version to 0.0.72 and update image tags

### DIFF
--- a/helm/raster-tiler/Chart.yaml
+++ b/helm/raster-tiler/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.71
+version: 0.0.72
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/raster-tiler/values/values-dev.yaml
+++ b/helm/raster-tiler/values/values-dev.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  tag: 5ecdccd134d2e7059e67307b0a3288c18e58ce70
+  tag: 7a142b040a61d43ae915ec8e5d6d40fcacfc93f0
   pullSecretName: none
   usePullSecret: false
 

--- a/helm/raster-tiler/values/values-prod.yaml
+++ b/helm/raster-tiler/values/values-prod.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  tag: 855746d73447fb4d6d8c73e0c71355dca82dd04a
+  tag: 7a142b040a61d43ae915ec8e5d6d40fcacfc93f0
   pullSecretName: none
   usePullSecret: false
 

--- a/helm/raster-tiler/values/values-test.yaml
+++ b/helm/raster-tiler/values/values-test.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  tag: 5ecdccd134d2e7059e67307b0a3288c18e58ce70
+  tag: 7a142b040a61d43ae915ec8e5d6d40fcacfc93f0
   pullSecretName: none
   usePullSecret: false
 


### PR DESCRIPTION
Update the version of the raster-tiler Helm chart to 0.0.72 and synchronize the image tags across all environments to 7a142b040a61d43ae915ec8e5d6d40fcacfc93f0. This ensures consistency and uses the latest image in all environments.