### PR TITLE
Bump version and adjust resource allocation

### DIFF
--- a/helm/raster-tiler/Chart.yaml
+++ b/helm/raster-tiler/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.72
+version: 0.0.73
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/raster-tiler/templates/deployment.yaml
+++ b/helm/raster-tiler/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: {{ .Values.resources.limits.cpu | quote }}
+              # cpu: {{ .Values.resources.limits.cpu | quote }}
               memory: {{ .Values.resources.limits.memory | quote }}
             requests:
               cpu: {{ .Values.resources.requests.cpu | quote }}

--- a/helm/raster-tiler/values.yaml
+++ b/helm/raster-tiler/values.yaml
@@ -9,7 +9,7 @@ image:
 
 db_disable_ssl: true
 port: 80
-replicas: 1
+replicas: 4
 envName: local
 ingressHost: none
 base_url: https://local-raster-tiler.k8s-01.konturlabs.com
@@ -27,7 +27,7 @@ probeInitialDelaySeconds: 30
 
 resources:
   requests:
-    cpu: 4
+    cpu: 2
     memory: 4Gi
   limits:
     cpu: 8


### PR DESCRIPTION
- Increment chart version to 0.0.73
- Comment out CPU limit in deployment template
- Increase replica count from 1 to 4
- Reduce CPU request from 4 to 2 in values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application to support increased scalability by adjusting the number of replicas from 1 to 4.
- **Refactor**
	- Adjusted CPU resource requests from 4 to 2 in deployment settings.
- **Chores**
	- Updated the application version to `0.0.73`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->