### PR TITLE
feat(flux/pgo/upa-db-exp): add new instance on hwn04 + new config (#19783, step 01)

### DIFF
--- a/flux/clusters/k8s-01/user-profile-api-db-exp/overlays/DEV/kustomization.yaml
+++ b/flux/clusters/k8s-01/user-profile-api-db-exp/overlays/DEV/kustomization.yaml
@@ -9,12 +9,20 @@ patchesJson6902:
       kind: PostgresCluster
       name: db-user-profile-api-exp
     path: postgrescluster-s3-backups.yaml
+  # NOTE: legacy, to be removed
   - target:
       group: postgres-operator.crunchydata.com
       version: v1beta1
       kind: PostgresCluster
       name: db-user-profile-api-exp
     path: postgrescluster-resource-adjustment.yaml
+  # NOTE: new config, to replace adjustment/assignment
+  - target:
+      group: postgres-operator.crunchydata.com
+      version: v1beta1
+      kind: PostgresCluster
+      name: db-user-profile-api-exp
+    path: postgrescluster-instances.yaml
 #  - target:
 #      group: postgres-operator.crunchydata.com
 #      version: v1beta1
@@ -33,6 +41,7 @@ patchesJson6902:
       kind: PostgresCluster
       name: db-user-profile-api-exp
     path: postgrescluster-custom-image.yaml
+  # NOTE: legacy, to be removed
   - target:
       group: postgres-operator.crunchydata.com
       version: v1beta1

--- a/flux/clusters/k8s-01/user-profile-api-db-exp/overlays/DEV/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/user-profile-api-db-exp/overlays/DEV/postgrescluster-instances.yaml
@@ -1,0 +1,28 @@
+# eventually it should be op: replace
+- op: add
+  path: /spec/instances/-
+  value:
+    name: hwn04
+    replicas: 1
+    resources:
+      limits:
+        memory: 12Gi
+        cpu: '4'
+      requests:
+        memory: 4Gi
+        cpu: '1'
+    dataVolumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 25Gi
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: In
+                  values:
+                    - hwn04.k8s-01.kontur.io


### PR DESCRIPTION

* Refactoring: new `instances` config is introduced, which is expected to
  * eventually *replace* `assigning` and `adjustment` configs
  * provide complete definition for every instance of cluster (including resources and affinity)
  * use meaninfgul names for instances

* Backwards-compatibility:
  * instance with name=`01` (pre-defined via `base` config) is temporary retained, as well as its affinity/resource tweaks

* Setup: new instance is added with name=hwn04 and appropriate nodeAffinity

* Desired effect: new instance is launched on hwn04 and starts catching up