### PR TITLE
feat(flux/pgo/upa-db-exp): switchover via flux (#19783, step 02)

### DIFF
--- a/flux/clusters/k8s-01/user-profile-api-db-exp/overlays/DEV/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/user-profile-api-db-exp/overlays/DEV/postgrescluster-instances.yaml
@@ -26,3 +26,16 @@
                   operator: In
                   values:
                     - hwn04.k8s-01.kontur.io
+# Switchover section
+# https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#changing-the-primary
+# https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#targeting-an-instance
+# 1. Requires fully-qualified instance id of new master
+# 2. New master must be in sink with current master (check via `patronictl list`)
+# 3. Its recommended to retain switchover section, to keep track of last desired master both in code and k8s
+- op: add
+  path: /spec/patroni/switchover
+  value:
+    enabled: true
+    trigger-switchover: "2024-09-30 [01]"
+    targetInstance: db-user-profile-api-exp-hwn04-5hmq
+    #type: Failover


### PR DESCRIPTION
* PREREQUISITES:
  * target replica should catch up to master
  * fully-qualified id of new master pod should be retrieved and used in config

See also:

https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#changing-the-primary

https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#targeting-an-instance