### PR TITLE
fix(flux/pgo/upa-db-exp): final refactoring -- when all overlays are switched to new schema, make base instances an empty placeholder (#19783, step 05)

### DIFF
--- a/flux/clusters/k8s-01/user-profile-api-db-exp/base/postgrescluster.yaml
+++ b/flux/clusters/k8s-01/user-profile-api-db-exp/base/postgrescluster.yaml
@@ -11,39 +11,7 @@ spec:
   backups:
     pgbackrest:
       image: 'registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.40-1'
-  instances:
-    - affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchLabels:
-                    postgres-operator.crunchydata.com/cluster: db-user-profile-api-exp
-                    postgres-operator.crunchydata.com/instance-set: '01'
-      dataVolumeClaimSpec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 25Gi
-      name: '01'
-      replicas: 1
-      resources:
-        limits:
-          memory: 12Gi
-          cpu: '4'
-        requests:
-          memory: 4Gi
-          cpu: '1'
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              postgres-operator.crunchydata.com/instance-set: '01'
+  instances: [] # placeholder, to be filled in overlays
   metadata:
     labels:
       app.kubernetes.io/component: database


### PR DESCRIPTION
The concept is to completely define named instances in overlays, not providing any defaults in base config