### PR TITLE
feat(flux/db-event-api/dev): switchover master to hwn04 (#19530/#19851 step 01.02)

### DIFF
--- a/flux/clusters/k8s-01/event-api-db/overlays/DEV/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/DEV/postgrescluster-instances.yaml
@@ -34,3 +34,23 @@
                   operator: In
                   values:
                     - hwn04.k8s-01.kontur.io
+
+# Switchover section
+# https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#changing-the-primary
+# https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#targeting-an-instance
+# 1. Requires fully-qualified instance id of new master
+# 2. New master must be in sink with current master (check via `patronictl list`)
+# 3. Its recommended to retain switchover section, to keep track of last desired master both in code and k8s
+- op: add
+  path: /spec/patroni/switchover
+  value:
+    enabled: true
+    targetInstance: db-event-api-hwn04-dpzz
+    #type: Failover
+# trigger-switchover annotation triggers actual switchover whenever its updated
+# value is arbitrary, but it's recommended to reference the date of switchover
+# special syntax is used to escape slash with sequence ~1
+# See https://windsock.io/json-pointer-syntax-in-json-patches-with-kustomize/
+- op: add
+  path: /metadata/annotations/postgres-operator.crunchydata.com~1trigger-switchover
+  value: "2024-10-09 14:33:00+00 (#19851)"


### PR DESCRIPTION

Prerequisites:
* hwn04 catched up to current master
* instance ID and trigger-switchover actualized in config

See more:
https://kontur.fibery.io/Tasks/document/Managing-PGO-instances-with-kustomize-1388/anchor=Switchover--4153b0a2-c4ff-441a-8913-158a3caac361