### PR TITLE
feat(flux/db-event-api/dev): add new slave on hwn03 (#19530 step 01.03)

### DIFF
--- a/flux/clusters/k8s-01/event-api-db/overlays/DEV/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/DEV/postgrescluster-instances.yaml
@@ -4,7 +4,7 @@
   value:
     name: hwn04
     replicas: 1
-    resources:
+    resources: &resources
       limits:
         memory: 512Gi # # let Postres use the page cache
         cpu: '64' # set as event-api pool size + autovacuum workers + a bit for parallel workers
@@ -17,7 +17,7 @@
         # empyrical recommendations below
         # memory: 7Gi
         # cpu: '1' 
-    dataVolumeClaimSpec:
+    dataVolumeClaimSpec: &storage
       accessModes:
         - ReadWriteOnce
       resources:
@@ -34,6 +34,24 @@
                   operator: In
                   values:
                     - hwn04.k8s-01.kontur.io
+- op: add
+  path: /spec/instances/-
+  value:
+    name: hwn03
+    replicas: 1
+    resources:
+      <<: *resources
+    dataVolumeClaimSpec:
+      <<: *storage
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: In
+                  values:
+                    - hwn03.k8s-01.kontur.io
 
 # Switchover section
 # https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#changing-the-primary


### PR DESCRIPTION
We already have replicas running on hwn03, but the goal is to have named instance on hwn03 (old replicas would be eliminated in next step)