### PR TITLE
feat(flux/db-event-api/prod): eliminate legacy instance and update instances config to final format [#19803]

### DIFF
--- a/flux/clusters/k8s-01/event-api-db/overlays/PROD/kustomization.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/PROD/kustomization.yaml
@@ -9,12 +9,6 @@ patchesJson6902:
       kind: PostgresCluster
       name: db-event-api
     path: postgrescluster-s3-backups.yaml
-  - target: # Legacy, to be removed but not until new replicas are set up and switchover is performed
-      group: postgres-operator.crunchydata.com
-      version: v1beta1
-      kind: PostgresCluster
-      name: db-event-api
-    path: postgrescluster-resource-adjustment.yaml
   - target: # new config for instances management
       group: postgres-operator.crunchydata.com
       version: v1beta1

--- a/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
@@ -1,57 +1,55 @@
-# eventually it should be op: replace
-- op: add
-  path: /spec/instances/-
+# Always replace placeholder instances from `base`
+- op: replace 
+  path: /spec/instances
   value:
-    name: hwn02 # see #19803
-    replicas: 1
-    resources: &resources
-      limits:
-        memory: 512Gi # # let Postres use the page cache
-        cpu: '64' # set as event-api pool size + autovacuum workers + a bit for parallel workers
-        # empyrical recommendations below
-        # memory: 100Gi 
-        # cpu: '5' 
-      requests:
-        memory: 22Gi # roughly shared_buffers + pool size * work_mem
-        cpu: '2' # if we don't have CPU we can run on potato
-        # empyrical recommendations below
-        # memory: 7Gi
-        # cpu: '1' 
-    dataVolumeClaimSpec: &pvc
-      accessModes:
-        - ReadWriteOnce
-      resources:
+    - name: hwn02 # see #19803
+      replicas: 1
+      resources: &resources
+        limits:
+          memory: 512Gi # # let Postres use the page cache
+          cpu: '64' # set as event-api pool size + autovacuum workers + a bit for parallel workers
+          # empyrical recommendations below
+          # memory: 100Gi 
+          # cpu: '5' 
         requests:
-          storage: 100Gi
-          # empyrical recommendations below -- actual storage varies from 2300Gi to 6200Gi
-          # storage: 2500Gi
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: In
-                  values:
-                    - hwn02.k8s-01.kontur.io
-- op: add
-  path: /spec/instances/-
-  value:
-    name: hwn03 # see #19803
-    replicas: 1
-    resources:
-      <<: *resources
-    dataVolumeClaimSpec:
-      <<: *pvc
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: In
-                  values:
-                    - hwn03.k8s-01.kontur.io
+          memory: 22Gi # roughly shared_buffers + pool size * work_mem
+          cpu: '2' # if we don't have CPU we can run on potato
+          # empyrical recommendations below
+          # memory: 7Gi
+          # cpu: '1' 
+      dataVolumeClaimSpec: &pvc
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+            # empyrical recommendations below -- actual storage varies from 2300Gi to 6200Gi
+            # storage: 2500Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - hwn02.k8s-01.kontur.io
+    - name: hwn03 # see #19803
+      replicas: 1
+      resources:
+        <<: *resources
+      dataVolumeClaimSpec:
+        <<: *pvc
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - hwn03.k8s-01.kontur.io
+
 #### switchover section ####
 # 2024-11-04: Switchover to hwn02 as a part of moving from legacy unnamed instances (#19803)
 

--- a/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-resource-adjustment.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-resource-adjustment.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/instances/0/replicas
-  value: 2


### PR DESCRIPTION
Purpose: migrating to multi-instances configuration
Prerequisites: switchover to hwn02 completed
Desired effect: instance set '01' is eliminated, cluster runs with two named instances on hwn02 (master) and hwn03 (replica)