### PR TITLE
Fix numeric timeout values

### DIFF
--- a/helm/raster-tiler/Chart.yaml
+++ b/helm/raster-tiler/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.91
+version: 0.0.92
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/raster-tiler/values/values-prod.yaml
+++ b/helm/raster-tiler/values/values-prod.yaml
@@ -18,8 +18,8 @@ storage_size: 500Gi
 storageClass: local-path
 db_pool_size: 8
 oam_layer_id: openaerialmap
-tile_fetch_timeout_ms: 1800000
-fetch_queue_ttl_ms: 3600000
+tile_fetch_timeout_ms: '1800000'
+fetch_queue_ttl_ms: '3600000'
 num_cpus: 24
 
 createResource:


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/OAM-Error-buffer-should-be-an-instance-of-Buffer-or-null-at-new-TileImage-20473