### PR TITLE
20913-basemap-default-language-in-new-york-is-not-english

### DIFF
--- a/helm/basemap/Chart.yaml
+++ b/helm/basemap/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.59
+version: 0.0.60
 
 #Don't use appVersion, use {{ .Values.images...tag's. }} instead. That's required for Flux automation - so that different
 # stages can have different versions within the same branch watched by Flux.

--- a/helm/basemap/values/values-dev.yaml
+++ b/helm/basemap/values/values-dev.yaml
@@ -24,7 +24,7 @@ basemap:
   # NOTE: when cluster runs on 3 nodes, to avoid resources starvation:
   #   1) either only *one* of dev/test/prod could be unsuspended
   #   2) or processing schedules of dev/test/prod should be coordinated to prevent simultaneous execution
-  # suspend: true # until image will be fixed, see #19951 and #19959
+  suspend: true # until image will be fixed, see #19951 and #19959
   processingSchedule: "0 13 */2 * *" # Run once in 2 days at midnight
   s3:
     path: s3://basemap-locker01/DEV/
@@ -33,7 +33,7 @@ basemap:
     endpoint: https://s3.kontur.io
   renderer:
     image: "nexus.kontur.io:8084/konturdev/build-basemap"
-    tag: "20913-basemap-default-language-in-new-york-is-not-english.cb5814b.1"
+    tag: "master.4219ce5.1"
   db:
     image: "nexus.kontur.io:8084/postgis/postgis"
     tag: "15-3.3"

--- a/helm/basemap/values/values-prod.yaml
+++ b/helm/basemap/values/values-prod.yaml
@@ -23,8 +23,8 @@ tileserver:
 basemap:
   # WARNING: job requires about 200G RAM and is stick to hwn02. Do not unsuspend without node capacity analysis!
   # NOTE: see values-dev for information on special conditions for suspend/processingSchedule
-  suspend: true # until image will be fixed, see #19951 and #19959
-  processingSchedule: "0 0 */2 * *" # Run once in 2 days at midnight
+  # suspend: true # until image will be fixed, see #19951 and #19959
+  processingSchedule: "0 16 */2 * *" # Run once in 2 days at midnight
   s3:
     path: s3://basemap-locker01/PROD/
     url: https://s3.kontur.io/basemap-locker01/PROD
@@ -32,7 +32,7 @@ basemap:
     endpoint: https://s3.kontur.io
   renderer:
     image: "nexus.kontur.io:8084/konturdev/build-basemap"
-    tag: "master.030fa6d.1"
+    tag: "master.4219ce5.1"
   db:
     image: "nexus.kontur.io:8084/postgis/postgis"
     tag: "15-3.3"


### PR DESCRIPTION
Deploy default language fix to prod and suspend generation on dev