### PR TITLE
Disable request buffering in ingress

### DIFF
--- a/helm/basemap/templates/ingress.yaml
+++ b/helm/basemap/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 5m

--- a/helm/disaster-ninja-fe/templates/ingress.yaml
+++ b/helm/disaster-ninja-fe/templates/ingress.yaml
@@ -24,6 +24,7 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/upstream-keepalive-connections: "32"
 
 

--- a/helm/epig/templates/ingress.yaml
+++ b/helm/epig/templates/ingress.yaml
@@ -19,6 +19,7 @@ metadata:
       proxy_bind off;
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
    {{ if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     {{ end }}

--- a/helm/event-api/templates/ingress.yaml
+++ b/helm/event-api/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 5m

--- a/helm/gateway/templates/ingress.yaml
+++ b/helm/gateway/templates/ingress.yaml
@@ -22,6 +22,7 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-headers: DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,User-Language
     nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/server-snippet: |
   {{- else }}

--- a/helm/insights-api/templates/ingress.yaml
+++ b/helm/insights-api/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.client_max_body_size }}

--- a/helm/insights-llm-api/templates/ingress.yaml
+++ b/helm/insights-llm-api/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
   nginx.ingress.kubernetes.io/enable-cors: "true"
   {{- else }}

--- a/helm/isochrone-api/templates/ingress.yaml
+++ b/helm/isochrone-api/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     acme.cert-manager.io/http01-edit-in-place: "true" #required otherwise ACME challenge can't be completed
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     {{ if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     {{ else }}

--- a/helm/keycloak/templates/ingress.yaml
+++ b/helm/keycloak/templates/ingress.yaml
@@ -24,6 +24,7 @@ metadata:
       }
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     {{ if .Values.isOfflineInstallation }}
     {{ else }}
     nginx.ingress.kubernetes.io/proxy-buffering: "on"

--- a/helm/layers-api/templates/ingress.yaml
+++ b/helm/layers-api/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 5m

--- a/helm/layers-tiles-api/templates/ingress.yaml
+++ b/helm/layers-tiles-api/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-production #use letsencrypt-staging for testing
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
   {{- else }}

--- a/helm/osrm/templates/ingress.yaml
+++ b/helm/osrm/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     acme.cert-manager.io/http01-edit-in-place: "true" #required otherwise ACME challenge can't be completed
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     {{ if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 5m

--- a/helm/raster-tiler/templates/ingress.yaml
+++ b/helm/raster-tiler/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
   {{- else }}

--- a/helm/titiler/templates/ingress.yaml
+++ b/helm/titiler/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
   {{- else }}

--- a/helm/user-profile-api/templates/ingress.yaml
+++ b/helm/user-profile-api/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   {{- if .Values.isOfflineInstallation }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
   {{- else }}


### PR DESCRIPTION
## Summary
- disable proxy request buffering in ingress templates so requests are streamed directly to the backends

## Testing
- `make -C helm template-test` *(fails: helm not found)*