### PR TITLE
Fix health probes for Keycloak and UPS

### DIFF
--- a/helm/keycloak/templates/deployment.yaml
+++ b/helm/keycloak/templates/deployment.yaml
@@ -73,8 +73,9 @@ spec:
           httpGet:
             path: /health
             port: {{ .Values.service.management }}
-          failureThreshold: 1
+          failureThreshold: 3
           periodSeconds: 15
+          timeoutSeconds: 5
           initialDelaySeconds: {{ .Values.probeInitialDelaySeconds }}
         {{ if .Values.createResource.deploymentLivenessProbe }}
         livenessProbe:
@@ -83,6 +84,7 @@ spec:
             port: {{ .Values.service.management }}
           failureThreshold: 10
           periodSeconds: 15
+          timeoutSeconds: 5
           initialDelaySeconds: {{ .Values.probeInitialDelaySeconds }}
         {{ end }}
       {{ if .Values.createResource.importDefaultRealm }}

--- a/helm/user-profile-api/templates/deployment.yaml
+++ b/helm/user-profile-api/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
               path: /health/liveness
               port: {{ .Values.management.port }}
             periodSeconds: 15
+            timeoutSeconds: 5
           {{- end }}
           name: user-profile-api
           ports:
@@ -82,7 +83,7 @@ spec:
               name: management
               protocol: TCP
           readinessProbe:
-            failureThreshold: 1
+            failureThreshold: 3
             httpGet:
               path: /health/readiness
               port: {{ .Values.management.port }}
@@ -90,7 +91,7 @@ spec:
             initialDelaySeconds: {{ .Values.probeInitialDelaySeconds }}
             periodSeconds: 15
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 5
           resources:
             limits:
               memory: {{ .Values.resources.limits.memory }}


### PR DESCRIPTION
## Summary
- tweak readiness/liveness probes for Keycloak chart
- fix user-profile-api probe failures by increasing thresholds and timeouts

## Testing
- `helm lint helm/keycloak` *(fails: `helm: command not found`)*
