### PR TITLE
Increase resources for keycloak

### DIFF
--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -9,7 +9,7 @@ image:
   pullSecretName: nexus8084
   usePullSecret: false
 
-replicas: 1
+replicas: 2
 
 service:
   main: 8080
@@ -30,9 +30,9 @@ probeInitialDelaySeconds: 180
 disableSsl: false
 
 resources:
-   requests:
-     cpu: 100m
-     memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 2Gi
    limits:
      memory: 16Gi
 

--- a/helm/keycloak/values/values-dev.yaml
+++ b/helm/keycloak/values/values-dev.yaml
@@ -9,7 +9,7 @@ image:
   pullSecretName: nexus8084
   usePullSecret: false
 
-replicas: 1
+replicas: 2
 
 service:
   main: 8080
@@ -45,9 +45,9 @@ probeInitialDelaySeconds: 180
 disableSsl: false
 
 resources:
-   requests:
+  requests:
      cpu: 100m
-     memory: 128Mi
+     memory: 2Gi
    limits:
      memory: 16Gi
 

--- a/helm/keycloak/values/values-prod.yaml
+++ b/helm/keycloak/values/values-prod.yaml
@@ -9,7 +9,7 @@ image:
   pullSecretName: nexus8084
   usePullSecret: false
 
-replicas: 1
+replicas: 2
 
 service:
   main: 8080
@@ -45,9 +45,9 @@ probeInitialDelaySeconds: 180
 disableSsl: false
 
 resources:
-   requests:
+  requests:
      cpu: 100m
-     memory: 128Mi
+     memory: 2Gi
    limits:
      memory: 16Gi
 

--- a/helm/keycloak/values/values-test.yaml
+++ b/helm/keycloak/values/values-test.yaml
@@ -9,7 +9,7 @@ image:
   pullSecretName: nexus8084
   usePullSecret: false
 
-replicas: 1
+replicas: 2
 
 service:
   main: 8080
@@ -45,9 +45,9 @@ probeInitialDelaySeconds: 180
 disableSsl: false
 
 resources:
-   requests:
+  requests:
      cpu: 100m
-     memory: 128Mi
+     memory: 2Gi
    limits:
      memory: 16Gi
 


### PR DESCRIPTION
## Summary
- increase keycloak replicas to 2
- bump Keycloak memory requests to 2Gi so the container can start reliably

## Testing
- `helm` not installed; linting skipped