### PR TITLE
Tune resource requests for Keycloak services

### DIFF
--- a/flux/clusters/k8s-01/keycloak-db/base/postgrescluster.yaml
+++ b/flux/clusters/k8s-01/keycloak-db/base/postgrescluster.yaml
@@ -44,8 +44,8 @@ spec:
           memory: 512Gi
           cpu: '64'
         requests:
-          memory: 32Gi
-          cpu: '2'
+          memory: 64Gi
+          cpu: '4'
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/flux/clusters/k8s-01/keycloak-db/overlays/DEV/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/keycloak-db/overlays/DEV/postgrescluster-instances.yaml
@@ -8,8 +8,8 @@
           memory: 512Gi
           cpu: '64'
         requests:
-          memory: 2Gi
-          cpu: '1'
+          memory: 64Gi
+          cpu: '4'
       dataVolumeClaimSpec:
         accessModes:
           - ReadWriteOnce

--- a/flux/clusters/k8s-01/keycloak-db/overlays/PROD/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/keycloak-db/overlays/PROD/postgrescluster-instances.yaml
@@ -8,8 +8,8 @@
           memory: 512Gi
           cpu: '64'
         requests:
-          memory: 2Gi
-          cpu: '1'
+          memory: 64Gi
+          cpu: '4'
       dataVolumeClaimSpec:
         accessModes:
           - ReadWriteOnce

--- a/flux/clusters/k8s-01/keycloak-db/overlays/TEST/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/keycloak-db/overlays/TEST/postgrescluster-instances.yaml
@@ -8,8 +8,8 @@
           memory: 512Gi
           cpu: '64'
         requests:
-          memory: 2Gi
-          cpu: '1'
+          memory: 64Gi
+          cpu: '4'
       dataVolumeClaimSpec:
         accessModes:
           - ReadWriteOnce

--- a/flux/clusters/k8s-01/user-profile-api-db/base/postgrescluster.yaml
+++ b/flux/clusters/k8s-01/user-profile-api-db/base/postgrescluster.yaml
@@ -44,8 +44,8 @@ spec:
           memory: 512Gi
           cpu: '64'
         requests:
-          memory: 4Gi
-          cpu: '1'
+          memory: 16Gi
+          cpu: '4'
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/flux/clusters/k8s-01/user-profile-api-db/overlays/DEV/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/user-profile-api-db/overlays/DEV/postgrescluster-instances.yaml
@@ -8,8 +8,8 @@
           memory: 512Gi
           cpu: '64'
         requests:
-          memory: 4Gi
-          cpu: '1'
+          memory: 16Gi
+          cpu: '4'
       dataVolumeClaimSpec:
         accessModes:
           - ReadWriteOnce

--- a/flux/clusters/k8s-01/user-profile-api-db/overlays/PROD/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/user-profile-api-db/overlays/PROD/postgrescluster-instances.yaml
@@ -8,8 +8,8 @@
           memory: 512Gi
           cpu: '64'
         requests:
-          memory: 4Gi
-          cpu: '1'
+          memory: 16Gi
+          cpu: '4'
       dataVolumeClaimSpec:
         accessModes:
           - ReadWriteOnce

--- a/flux/clusters/k8s-01/user-profile-api-db/overlays/TEST/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/user-profile-api-db/overlays/TEST/postgrescluster-instances.yaml
@@ -8,8 +8,8 @@
           memory: 512Gi
           cpu: '64'
         requests:
-          memory: 4Gi
-          cpu: '1'
+          memory: 16Gi
+          cpu: '4'
       dataVolumeClaimSpec:
         accessModes:
           - ReadWriteOnce

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -31,8 +31,8 @@ disableSsl: false
 
 resources:
    requests:
-     cpu: 100m
-     memory: 128Mi
+     cpu: 1000m
+     memory: 2Gi
    limits:
      memory: 16Gi
 

--- a/helm/keycloak/values/values-dev.yaml
+++ b/helm/keycloak/values/values-dev.yaml
@@ -45,9 +45,9 @@ probeInitialDelaySeconds: 180
 disableSsl: false
 
 resources:
-   requests:
-     cpu: 100m
-     memory: 4Gi
+  requests:
+     cpu: 1000m
+     memory: 8Gi
    limits:
      memory: 16Gi
 

--- a/helm/keycloak/values/values-prod.yaml
+++ b/helm/keycloak/values/values-prod.yaml
@@ -45,9 +45,9 @@ probeInitialDelaySeconds: 180
 disableSsl: false
 
 resources:
-   requests:
-     cpu: 100m
-     memory: 4Gi
+  requests:
+     cpu: 1000m
+     memory: 8Gi
    limits:
      memory: 16Gi
 

--- a/helm/keycloak/values/values-quickstart.yaml
+++ b/helm/keycloak/values/values-quickstart.yaml
@@ -42,9 +42,9 @@ probeInitialDelaySeconds: 360
 disableSsl: true
 
 resources:
-   requests:
-     cpu: 100m
-     memory: 128Mi
+  requests:
+     cpu: 1000m
+     memory: 2Gi
    limits:
      memory: 16Gi
 

--- a/helm/keycloak/values/values-test.yaml
+++ b/helm/keycloak/values/values-test.yaml
@@ -45,9 +45,9 @@ probeInitialDelaySeconds: 180
 disableSsl: false
 
 resources:
-   requests:
-     cpu: 100m
-     memory: 4Gi
+  requests:
+     cpu: 1000m
+     memory: 8Gi
    limits:
      memory: 16Gi
 

--- a/helm/user-profile-api/values.yaml
+++ b/helm/user-profile-api/values.yaml
@@ -26,8 +26,8 @@ probeInitialDelaySeconds: 15
 
 resources:
   requests:
-    cpu: 100m
-    memory: 4Gi
+    cpu: 1000m
+    memory: 8Gi
   limits:
     memory: 16Gi
 


### PR DESCRIPTION
## Summary
- bump CPU and memory requests for `keycloak` service
- increase resources for `user-profile-api`
- allocate more resources for keycloak & user-profile PostgreSQL clusters

## Testing
- `helm version --short` *(fails: command not found)*
- `kustomize version --short` *(fails: command not found)*