### PR TITLE
Add Sentry placeholders

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -105,4 +105,8 @@ Address: 192.168.64.2
 **- Further steps:**
 
 - If you don't want to reinstall the entire platform but just want to deploy your changes, use
-```make helm-install-quickstart-all``` to upgrade all helm releases or ```make disaster-ninja-fe``` to upgrade a single release. See the list of available goals in ```Makefile``` 
+```make helm-install-quickstart-all``` to upgrade all helm releases or ```make disaster-ninja-fe``` to upgrade a single release. See the list of available goals in ```Makefile```
+
+## Sentry
+
+Several charts include placeholders to enable [Sentry](https://sentry.io) error reporting. The DSN string is expected in a Kubernetes Secret under the key `SENTRY_DSN`. Replace the default value in `templates/secret.yaml` of each chart (for example `keycloak` and `user-profile-api`) with the DSN from your Sentry project before deploying.

--- a/helm/keycloak/templates/secret.yaml
+++ b/helm/keycloak/templates/secret.yaml
@@ -16,5 +16,6 @@ data:
   DB_PASSWORD: cGFzc3dvcmQ= # = 'password'
   KEYCLOAK_PASSWORD: cGFzc3dvcmQ= # = 'password' #if KEYCLOAK_USER is set in configmap, a new user will be created with this password
   USP_DB_PASSWORD: cGFzc3dvcmQ= # = 'password'
+  SENTRY_DSN: c2VjcmV0Cg== # base64 for 'secret'
 ---
 {{ end }}

--- a/helm/user-profile-api/templates/secret.yaml
+++ b/helm/user-profile-api/templates/secret.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 data:
     SPRING_DATASOURCE_PASSWORD: cGFzc3dvcmQ= # = 'password'
+    SENTRY_DSN: c2VjcmV0Cg== # base64 for 'secret'
 kind: Secret
 metadata:
   annotations:


### PR DESCRIPTION
## Summary
- add Sentry DSN placeholders for keycloak and user-profile-api Helm charts
- mention Sentry secrets in Helm README

## Testing
- `git status --short`