### PR TITLE
Add layers-stac-api service

### DIFF
--- a/flux/base/layers-stac-api/helmrelease-layers-stac-api.yaml
+++ b/flux/base/layers-stac-api/helmrelease-layers-stac-api.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: layers-stac-api
+spec:
+  chart:
+    spec:
+      chart: ./helm/layers-stac-api
+      interval: 1m
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: GitRepository
+        name: kontur-platform
+        namespace: flux-system
+      valuesFiles:
+        - ./helm/layers-stac-api/values.yaml
+  interval: 5m
+  suspend: false
+  test:
+    enable: true
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+  values:
+    k8s_cluster_flavor: '${k8s_cluster_flavor}' # optional value that can be substituted in a Flux pipeline

--- a/flux/base/layers-stac-api/kustomization.yaml
+++ b/flux/base/layers-stac-api/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease-layers-stac-api.yaml

--- a/flux/clusters/k8s-01/kustomization.yaml
+++ b/flux/clusters/k8s-01/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - layers-api
   - layers-db-etl
   - layers-tiles-api
+  - layers-stac-api
   - osrm
   - raster-tiler
   - titiler

--- a/flux/clusters/k8s-01/layers-db/base/configmap.yaml
+++ b/flux/clusters/k8s-01/layers-db/base/configmap.yaml
@@ -15,6 +15,11 @@ data:
     GRANT SELECT ON layers_features TO "layers-tiles-api";
     GRANT EXECUTE ON FUNCTION hot_projects(integer, integer, integer) TO "layers-tiles-api";
     GRANT EXECUTE ON FUNCTION hot_projects_outlines(integer, integer, integer) TO "layers-tiles-api";
+
+    GRANT SELECT ON layers TO "layers-stac-api";
+    GRANT SELECT ON layers_features TO "layers-stac-api";
+    GRANT EXECUTE ON FUNCTION hot_projects(integer, integer, integer) TO "layers-stac-api";
+    GRANT EXECUTE ON FUNCTION hot_projects_outlines(integer, integer, integer) TO "layers-stac-api";
      
     ALTER TABLE layers                     OWNER TO "layers-api";
     ALTER TABLE apps                       OWNER TO "layers-api";

--- a/flux/clusters/k8s-01/layers-stac-api/dev/kustomization.yaml
+++ b/flux/clusters/k8s-01/layers-stac-api/dev/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/layers-stac-api
+namePrefix: dev-
+namespace: dev-layers-stac-api
+patches:
+  - target:
+      kind: HelmRelease
+      name: layers-stac-api
+      group: helm.toolkit.fluxcd.io
+      version: v2beta1
+    patch: |-
+      - op: replace
+        path: /spec/chart/spec/valuesFiles
+        value:
+          - ./helm/layers-stac-api/values.yaml
+          - ./helm/layers-stac-api/values/values-dev.yaml

--- a/flux/clusters/k8s-01/layers-stac-api/kustomization.yaml
+++ b/flux/clusters/k8s-01/layers-stac-api/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dev
+  - test
+  - prod

--- a/flux/clusters/k8s-01/layers-stac-api/prod/kustomization.yaml
+++ b/flux/clusters/k8s-01/layers-stac-api/prod/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/layers-stac-api
+namePrefix: prod-
+namespace: prod-layers-stac-api
+patches:
+  - target:
+      kind: HelmRelease
+      name: layers-stac-api
+      group: helm.toolkit.fluxcd.io
+      version: v2beta1
+    patch: |-
+      - op: replace
+        path: /spec/chart/spec/valuesFiles
+        value:
+          - ./helm/layers-stac-api/values.yaml
+          - ./helm/layers-stac-api/values/values-prod.yaml

--- a/flux/clusters/k8s-01/layers-stac-api/test/kustomization.yaml
+++ b/flux/clusters/k8s-01/layers-stac-api/test/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/layers-stac-api
+namePrefix: test-
+namespace: test-layers-stac-api
+patches:
+  - target:
+      kind: HelmRelease
+      name: layers-stac-api
+      group: helm.toolkit.fluxcd.io
+      version: v2beta1
+    patch: |-
+      - op: replace
+        path: /spec/chart/spec/valuesFiles
+        value:
+          - ./helm/layers-stac-api/values.yaml
+          - ./helm/layers-stac-api/values/values-test.yaml

--- a/helm/layers-stac-api/.helmignore
+++ b/helm/layers-stac-api/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/layers-stac-api/Chart.yaml
+++ b/helm/layers-stac-api/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: layers-stac-api
+description: A Helm chart for Layers STAC API
+
+type: application
+
+version: 0.1.0
+# don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/layers-stac-api/templates/configmap.yaml
+++ b/helm/layers-stac-api/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  PGHOST: "{{ .Values.pgHost }}"
+  PGPORT: "{{ .Values.pgPort }}"
+  PGDATABASE: "{{ .Values.pgDatabase }}"
+  PGUSER: "{{ .Values.pgUser }}"
+  LAYERSDBSTAGE: "{{ .Values.envName }}"
+kind: ConfigMap
+metadata:
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Values.envName }}-layers-stac-api
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: layers-stac-api
+    stage: {{ .Values.envName }}
+  name: {{ .Values.envName }}-layers-stac-api
+  namespace: {{ .Release.Namespace }}

--- a/helm/layers-stac-api/templates/deployment.yaml
+++ b/helm/layers-stac-api/templates/deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Values.envName }}-layers-stac-api
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: layers-stac-api
+    stage: {{ .Values.envName }}
+  name: {{ .Values.envName }}-layers-stac-api
+  namespace: {{ .Release.Namespace }}
+spec:
+  progressDeadlineSeconds: 600
+  replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Values.envName }}-layers-stac-api
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: layers-stac-api
+      stage: {{ .Values.envName }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: {{ .Release.Name }}
+        meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/instance: {{ .Values.envName }}-layers-stac-api
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: layers-stac-api
+        stage: {{ .Values.envName }}
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: {{ .Values.envName }}-layers-stac-api
+            - secretRef:
+                name: {{ .Values.envName }}-layers-stac-api
+          env:
+            - name: ENABLED_EXTENSIONS
+              value: "{{ .Values.enabledExtensions }}"
+            - name: POSTGRES_USER
+              value: $(PGUSER)
+            - name: POSTGRES_PASS
+              value: $(PGPASSWORD)
+            - name: POSTGRES_HOST_READER
+              value: $(PGHOST)
+            - name: POSTGRES_HOST_WRITER
+              value: $(PGHOST)
+            - name: POSTGRES_PORT
+              value: $(PGPORT)
+            - name: POSTGRES_DBNAME
+              value: $(PGDATABASE)
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["uvicorn"]
+          args: ["stac_fastapi.pgstac.app:app","--host","0.0.0.0","--port","{{ .Values.containerPort }}","--workers","4"]
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.containerPort }}
+            failureThreshold: 10
+            initialDelaySeconds: {{ .Values.probeInitialDelaySeconds }}
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.containerPort }}
+            failureThreshold: 1
+            initialDelaySeconds: {{ .Values.probeInitialDelaySeconds }}
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: layers-stac-api
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+              name: stac
+              protocol: TCP
+          resources:
+            limits:
+              memory: {{ .Values.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.resources.requests.cpu | quote }}
+              memory: {{ .Values.resources.requests.memory }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/helm/layers-stac-api/templates/secret.yaml
+++ b/helm/layers-stac-api/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.createResource.defaultSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.envName }}-layers-stac-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: layers-stac-api
+    app.kubernetes.io/instance: {{ .Values.envName }}-layers-stac-api
+    app.kubernetes.io/managed-by: "Helm"
+    stage: {{ .Values.envName }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+data:
+  PGPASSWORD: cGFzc3dvcmQ= # = 'password'
+{{ end }}

--- a/helm/layers-stac-api/templates/service.yaml
+++ b/helm/layers-stac-api/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Values.envName }}-layers-stac-api
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: layers-stac-api
+    stage: {{ .Values.envName }}
+  name: {{ .Values.envName }}-layers-stac-api
+  namespace: {{ .Release.Namespace }}
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: stac
+      port: {{ .Values.containerPort }}
+      protocol: TCP
+      targetPort: stac
+  selector:
+    app.kubernetes.io/instance: {{ .Values.envName }}-layers-stac-api
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: layers-stac-api
+    stage: {{ .Values.envName }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/helm/layers-stac-api/values.yaml
+++ b/helm/layers-stac-api/values.yaml
@@ -1,0 +1,33 @@
+# Default values for layers-stac-api.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: ghcr.io/stac-utils/stac-fastapi
+  pullPolicy: IfNotPresent
+  tag: latest
+
+containerPort: 8080
+replicas: 1
+envName: local
+
+enabledExtensions: free_text,filter,sort,query,collection_search,pagination,fields
+
+createResource:
+  defaultSecrets: false
+isOfflineInstallation: false
+probeInitialDelaySeconds: 15
+
+resources:
+  requests:
+    cpu: 1
+    memory: 1Gi
+  limits:
+    memory: 2Gi
+
+pgHost: host.docker.internal
+pgPort: 5432
+pgDatabase: layers-db
+pgUser: layers-db
+
+k8s_cluster_flavor: default

--- a/helm/layers-stac-api/values/values-dev.yaml
+++ b/helm/layers-stac-api/values/values-dev.yaml
@@ -1,0 +1,10 @@
+# DEV values for layers-stac-api.
+image:
+  tag: latest
+replicas: 1
+envName: dev
+createResource:
+  defaultSecrets: false
+isOfflineInstallation: false
+probeInitialDelaySeconds: 15
+pgHost: db-layers-primary.dev-layers-db.svc

--- a/helm/layers-stac-api/values/values-prod.yaml
+++ b/helm/layers-stac-api/values/values-prod.yaml
@@ -1,0 +1,10 @@
+# PROD values for layers-stac-api.
+image:
+  tag: latest
+replicas: 1
+envName: prod
+createResource:
+  defaultSecrets: false
+isOfflineInstallation: false
+probeInitialDelaySeconds: 15
+pgHost: db-layers-primary.prod-layers-db.svc

--- a/helm/layers-stac-api/values/values-quickstart.yaml
+++ b/helm/layers-stac-api/values/values-quickstart.yaml
@@ -1,0 +1,10 @@
+# QUICKSTART values for layers-stac-api.
+image:
+  tag: latest
+replicas: 1
+envName: quickstart
+createResource:
+  defaultSecrets: true
+isOfflineInstallation: true
+probeInitialDelaySeconds: 90
+pgHost: host.docker.internal

--- a/helm/layers-stac-api/values/values-test.yaml
+++ b/helm/layers-stac-api/values/values-test.yaml
@@ -1,0 +1,10 @@
+# TEST values for layers-stac-api.
+image:
+  tag: latest
+replicas: 1
+envName: test
+createResource:
+  defaultSecrets: false
+isOfflineInstallation: false
+probeInitialDelaySeconds: 15
+pgHost: db-layers-primary.test-layers-db.svc


### PR DESCRIPTION
## Summary
- add Helm chart for `layers-stac-api`
- deploy `layers-stac-api` via Flux kustomizations
- grant DB access to the new service

## Testing
- `helm lint helm/layers-stac-api` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846f354b7308324a6247108cc3af233