### PR TITLE
Switch dev epig to Vulkan

### DIFF
--- a/helm/epig/Chart.yaml
+++ b/helm/epig/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.35
+version: 0.1.36
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/epig/values/values-dev.yaml
+++ b/helm/epig/values/values-dev.yaml
@@ -12,7 +12,7 @@ TIMEOUT: 8000
 CACHE_TTL: 120
 DEBUG: TRUE
 #DEFAULT_IMAGE_URL: "https://test-apps-ninja02.konturlabs.com/active/static/assets/preview_screenshot.png"
-CHROMIUM_GPU_MODE: gl
+CHROMIUM_GPU_MODE: vulkan
 
 containers:
   pullSecretName: none


### PR DESCRIPTION
## Summary
- use Vulkan for `CHROMIUM_GPU_MODE` in `values-dev.yaml`
- bump epig chart version to `0.1.36`

## Testing
- `helm lint helm/epig` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68688254e8088324a0022469d8879828