### PR TITLE
Configure Sentry for Chromium

### DIFF
--- a/helm/epig/templates/chromium-headless-deployment.yaml
+++ b/helm/epig/templates/chromium-headless-deployment.yaml
@@ -55,6 +55,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Values.ENV_NAME }}-epig
+            - secretRef:
+                name: {{ .Values.ENV_NAME }}-preview-generator-secret
           ports:
             - containerPort: {{ .Values.CHROMIUM_PORT }}
           resources:


### PR DESCRIPTION
## Summary
- send env vars from the epig preview-generator secret to the chromium-headless container

## Testing
- `helm lint helm/epig` *(fails: `helm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68688aa32d608324861eca3ebe112f6a