### PR TITLE
Update dev CHROMIUM_GPU_MODE

### DIFF
--- a/helm/epig/Chart.yaml
+++ b/helm/epig/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.37
+version: 0.1.38
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/epig/values/values-dev.yaml
+++ b/helm/epig/values/values-dev.yaml
@@ -12,7 +12,7 @@ TIMEOUT: 8000
 CACHE_TTL: 120
 DEBUG: TRUE
 #DEFAULT_IMAGE_URL: "https://test-apps-ninja02.konturlabs.com/active/static/assets/preview_screenshot.png"
-CHROMIUM_GPU_MODE: vulkan
+CHROMIUM_GPU_MODE: gl
 containers:
   pullSecretName: none
   usePullSecret: false


### PR DESCRIPTION
## Summary
- set `CHROMIUM_GPU_MODE` to `gl` for the dev environment
- bump epig chart version to force rollout

## Testing
- `helm lint helm/epig` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68689ae20a6c8324a99ac7463769d3e2