### PR TITLE
Fix GPU scheduling by using recreate strategy

### DIFF
--- a/helm/epig/Chart.yaml
+++ b/helm/epig/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.39
+version: 0.1.40
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/epig/templates/chromium-headless-deployment.yaml
+++ b/helm/epig/templates/chromium-headless-deployment.yaml
@@ -22,10 +22,14 @@ spec:
       stage: {{ .Values.ENV_NAME }}
   replicas: {{ .Values.containers.chromium_headless.replicas }}
   strategy:
+    {{- if or (.Values.resources.chromium.requests.nvidia_gpu) (.Values.resources.chromium.limits.nvidia_gpu) }}
+    type: Recreate
+    {{- else }}
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+    {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary
- use `Recreate` deployment strategy when Chromium requests GPU
- bump epig chart version to 0.1.40

## Testing
- `helm lint helm/epig` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686952a19c8c8324bfc927e42d7b0a6b