### PR TITLE
Add Java heap limit for insights-api

### DIFF
--- a/helm/insights-api/Chart.yaml
+++ b/helm/insights-api/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.445
+version: 0.0.446
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/insights-api/templates/deployment.yaml
+++ b/helm/insights-api/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
     {{- end }}
       containers:
         - env:
+            - name: JAVA_TOOL_OPTIONS
+              value: -XX:MaxRAMPercentage=50
             - name: OTEL_SERVICE_NAME
               valueFrom:
                 fieldRef:

--- a/helm/insights-api/values.yaml
+++ b/helm/insights-api/values.yaml
@@ -58,3 +58,5 @@ client_max_body_size: 100g
 proxy_read_timeout: 600s
 
 k8s_cluster_flavor: default # value may be substituted in a Flux pipeline
+
+java_tool_options: "-XX:MaxRAMPercentage=50"

--- a/helm/insights-api/values/values-dev.yaml
+++ b/helm/insights-api/values/values-dev.yaml
@@ -60,3 +60,5 @@ maxH3Resolution: 11
 minH3Resolution: 0
 maxZoom: 15
 minZoom: 0
+
+java_tool_options: "-XX:MaxRAMPercentage=50"

--- a/helm/insights-api/values/values-prod.yaml
+++ b/helm/insights-api/values/values-prod.yaml
@@ -64,3 +64,5 @@ maxH3Resolution: 11
 minH3Resolution: 0
 maxZoom: 15
 minZoom: 0
+
+java_tool_options: "-XX:MaxRAMPercentage=50"

--- a/helm/insights-api/values/values-quickstart.yaml
+++ b/helm/insights-api/values/values-quickstart.yaml
@@ -54,3 +54,5 @@ otlpTracesPort: 4317
 client_max_body_size: 5g
 
 jdbcTemplateQueryTimeout: "600"
+
+java_tool_options: "-XX:MaxRAMPercentage=50"

--- a/helm/insights-api/values/values-test.yaml
+++ b/helm/insights-api/values/values-test.yaml
@@ -62,3 +62,5 @@ maxH3Resolution: 11
 minH3Resolution: 0
 maxZoom: 15
 minZoom: 0
+
+java_tool_options: "-XX:MaxRAMPercentage=50"


### PR DESCRIPTION
## Summary
- configure `JAVA_TOOL_OPTIONS` in insights-api deployment to restrict heap usage to 50%
- expose `java_tool_options` in default and env-specific values
- bump insights-api chart version

## Testing
- `helm lint helm/insights-api` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870eadecf988324baf76f2e1668551f