### PR TITLE
Fix event-api max_map_count warning

### DIFF
--- a/helm/event-api/Chart.yaml
+++ b/helm/event-api/Chart.yaml
@@ -15,6 +15,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.189
+version: 0.1.190
 
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/event-api/templates/deployment.yaml
+++ b/helm/event-api/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       imagePullSecrets: #TODO remove once image is on ghcr.io
         - name: {{ .Values.image.pullSecretName }}
       {{- end }}
+      securityContext:
+        sysctls:
+          - name: vm.max_map_count
+            value: "{{ .Values.vmMaxMapCount }}"
       containers:
         - env:
             - name: OTEL_SERVICE_NAME

--- a/helm/event-api/values.yaml
+++ b/helm/event-api/values.yaml
@@ -25,6 +25,7 @@ isOfflineInstallation: false
 probeInitialDelaySeconds: 15
 probeInitialDelaySecondsRedis: 15
 usePgDataSecret: false
+vmMaxMapCount: 262144
 
 resources:
   app:


### PR DESCRIPTION
## Summary
- allow customizing `vm.max_map_count` for event-api pods
- set default `vmMaxMapCount` and bump chart version

## Testing
- `helm lint` *(fails: `helm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687117104f2c832a952ff82c077da4c0