### PR TITLE
Spinning up new prod-event-api-db replica on hwn04 despite prevent-new-pods taint (#22264)

### DIFF
--- a/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
@@ -55,6 +55,7 @@
     - <<: *base
       name: hwn04
       affinity:
+        nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:

--- a/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
@@ -26,7 +26,8 @@
                     operator: In
                     values:
                       - hwn01.k8s-01.kontur.io
-    - name: hwn02a
+    - &base
+      name: hwn02a
       replicas: 1
       resources:
         limits:
@@ -50,6 +51,18 @@
                     operator: In
                     values:
                       - hwn02.k8s-01.kontur.io
+
+    - <<: *base
+      name: hwn04
+      affinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - hwn04.k8s-01.kontur.io
+      
 
 #### switchover section ####
 # 2024-11-04: Switchover to hwn02 as a part of moving from legacy unnamed instances (#19803)

--- a/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
@@ -63,6 +63,10 @@
                     operator: In
                     values:
                       - hwn04.k8s-01.kontur.io
+      tolerations:
+        - key: "prevent-new-pods"
+          operator: "Exists"
+          effect: "NoSchedule"
       
 
 #### switchover section ####


### PR DESCRIPTION
We need replica there to free some space on hwn01