### PR TITLE
Enable GPU scheduling for EPIG test

### DIFF
--- a/helm/epig/Chart.yaml
+++ b/helm/epig/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.48
+version: 0.1.50
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/epig/values/values-test.yaml
+++ b/helm/epig/values/values-test.yaml
@@ -12,16 +12,17 @@ TIMEOUT: 8000
 CACHE_TTL: 600
 DEBUG: TRUE
 #DEFAULT_IMAGE_URL: "https://test-apps-ninja01.konturlabs.com/active/static/assets/preview_screenshot.png"
+CHROMIUM_GPU_MODE: egl
 
 containers:
   pullSecretName: none
   usePullSecret: false
   chromium_headless:
     replicas: 1
-    tag: main.0be7352.1
+    tag: main.e84b023.1
   preview_generator:
     replicas: 1
-    tag: main.0be7352.1
+    tag: main.e84b023.1
   redis:
     replicas: 1
     tag: "7-alpine3.16"
@@ -29,3 +30,4 @@ resources:
   chromium:
     requests:
       cpu: 500m
+      gpu_memory: "2000"


### PR DESCRIPTION
## Summary
- enable GPU for EPIG test environment similar to dev
- bump epig chart version
- update container tags to match dev

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884ac3578ec8324b23a9193cf841649