### PR TITLE
Enable GPU for prod epig

### DIFF
--- a/helm/epig/Chart.yaml
+++ b/helm/epig/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.50
+version: 0.1.52
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/epig/values/values-prod.yaml
+++ b/helm/epig/values/values-prod.yaml
@@ -13,16 +13,17 @@ TIMEOUT: 8000
 CACHE_TTL: 3600
 DEBUG: TRUE
 #DEFAULT_IMAGE_URL: "https://disaster.ninja/active/static/assets/preview_screenshot.png"
+CHROMIUM_GPU_MODE: egl
 
 containers:
   pullSecretName: none
   usePullSecret: false
   chromium_headless:
     replicas: 1
-    tag: main.0be7352.1
+    tag: main.e84b023.1
   preview_generator:
     replicas: 1
-    tag: main.0be7352.1
+    tag: main.e84b023.1
   redis:
     replicas: 1
     tag: "7-alpine3.16"
@@ -30,3 +31,4 @@ resources:
   chromium:
     requests:
       cpu: 500m
+      gpu_memory: "2000"


### PR DESCRIPTION
## Summary
- update prod epig chart to use GPU via fractional scheduling
- sync prod container versions with test
- bump epig chart version

## Testing
- `helm lint helm/epig` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884b39cb8248324ad8a5f581e4c5f09