### PR TITLE
feat(flux/db-event-api/prod): run replica on gpu01 instead of hwn04 [#22264]

### DIFF
--- a/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
@@ -53,7 +53,7 @@
                       - hwn02.k8s-01.kontur.io
 
     - <<: *base
-      name: hwn04
+      name: gpu01
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -62,9 +62,9 @@
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - hwn04.k8s-01.kontur.io
+                      - gpu01.k8s-01.kontur.io
       tolerations:
-        - key: "prevent-new-pods"
+        - key: "nvidia.com/gpu"
           operator: "Exists"
           effect: "NoSchedule"
       


### PR DESCRIPTION
Replica on hwn04 was not provisioned due to disk issue, so running on gpu01 instead