### PR TITLE
fix(flux/db-insights-api/test): increase pgbackrest archive-timeout to 4h [#22213]

### DIFF
--- a/flux/clusters/k8s-01/insights-api-db/overlays/TEST-PG17/postgrescluster-pgbackrest-adjustment.yaml
+++ b/flux/clusters/k8s-01/insights-api-db/overlays/TEST-PG17/postgrescluster-pgbackrest-adjustment.yaml
@@ -1,6 +1,7 @@
+# 4h is the biggest WAL archivation lag we observed; 4h=14400s
 - op: add
   path: /spec/backups/pgbackrest/global/archive-timeout
-  value: '1200'
+  value: '14400'
 
 - op: add
   path: /spec/backups/pgbackrest/global/process-max


### PR DESCRIPTION
The biggest WAL lag we observed was about 4h -- setting timeout to this scope to see if it helps