### PR TITLE
fix(flux/clusters/prod-event-api-db): reverting occasional leadership…

### DIFF
--- a/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
+++ b/flux/clusters/k8s-01/event-api-db/overlays/PROD/postgrescluster-instances.yaml
@@ -71,26 +71,25 @@
 
 #### switchover section ####
 # 2024-11-04: Switchover to hwn02 as a part of moving from legacy unnamed instances (#19803)
+# 2025-07-31: Switchover to 'hwn02a' from 'hwn02' ('hwn02' became master occasionally, but is desired for deletion)
 
 # https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#changing-the-primary
 # https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/cluster-management/administrative-tasks#targeting-an-instance
 # 1. Requires fully-qualified instance id of new master
 # 2. New master must be in sink with current master (check via `patronictl list`)
 # 3. Its recommended to retain switchover section, to keep track of last desired master both in code and k8s
-### Commented out because replicas are absent.
-#- op: add
-#  path: /spec/patroni/switchover
-#  value:
-#    enabled: true
-#    targetInstance: db-event-api-hwn03-l8jw
-#    #type: Failover
+- op: add
+  path: /spec/patroni/switchover
+  value:
+    enabled: true
+    targetInstance: db-event-api-hwn02a-28kg
+    #type: Failover
 ###
 # trigger-switchover annotation triggers actual switchover whenever its updated
 # value is arbitrary, but it's recommended to reference the date of switchover
 # special syntax is used to escape slash with sequence ~1
 # See https://windsock.io/json-pointer-syntax-in-json-patches-with-kustomize/
-### Commented out because replicas are absent.
-#- op: add
-#  path: /metadata/annotations/postgres-operator.crunchydata.com~1trigger-switchover
-#  value: 2024-12-12-1 # reason: replica migration (#20407)
+- op: add
+  path: /metadata/annotations/postgres-operator.crunchydata.com~1trigger-switchover
+  value: 2025-07-31-hwn02 # reason: planned replica deletion, reverting occasional leadership (#22264)
 ###


### PR DESCRIPTION
… from hwn02 to hwn02a as hwn02 is planned for deletion [#22264]

(and is also named confusingly! :) ) 