### PR TITLE
chore(event-api): deploy master.44dd526.1 to test and prod

### DIFF
--- a/helm/event-api/Chart.yaml
+++ b/helm/event-api/Chart.yaml
@@ -13,5 +13,5 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.268
+version: 0.1.269
 # don't use appVersion, use {{Values.image.tag}} instead

--- a/helm/event-api/values/values-prod.yaml
+++ b/helm/event-api/values/values-prod.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  tag: master.d31963c2.1
+  tag: master.44dd526.1
   pullSecretName: none
   usePullSecret: false
 

--- a/helm/event-api/values/values-test.yaml
+++ b/helm/event-api/values/values-test.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  tag: master.d31963c2.1
+  tag: master.44dd526.1
   pullSecretName: none
   usePullSecret: false
 


### PR DESCRIPTION
## Summary
- align event-api test and prod deployments with dev by using image tag `master.44dd526.1`
- bump event-api chart version to 0.1.269

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*


------
https://chatgpt.com/codex/tasks/task_e_68b2e584133083249b696598d35eaf30